### PR TITLE
Add buzzer

### DIFF
--- a/PowderHopperGauge.ino
+++ b/PowderHopperGauge.ino
@@ -58,9 +58,11 @@ using namespace Menu;
 //SCL=5 => D1
 
 // Define pins for rotary encoder
-#define encA D6
-#define encB D7
-#define encBtn D4
+// Corresponds to the GPIO For the Pin
+// Google Image Search "ESP8266 Pinout" 
+#define encA 12
+#define encB 13
+#define encBtn 2
 #define encSteps 4
 
 // Declare the clickEncoder

--- a/PowderHopperGauge.ino
+++ b/PowderHopperGauge.ino
@@ -51,6 +51,14 @@ extern "C"
 //  SCL         D1        // Hardcoded on ESP8266 so must be D1
 //  SDA         D2        // Hardcoded on ESP8266 so must be D2
 
+// Alarm Buzzer Wiring:
+//
+//  Buzzer     ESP8266    Description
+//   Wire       Pins
+//
+//  Red         D8       // Could be any good input pin *EXCEPT GPIO 3 or 11*
+//  Black       GND      //  Wire a 100 ohm resistor inline betwen the buzzer and the gnd
+
 using namespace Menu;
 
 // No need to declare pins for 6180 sensor if you use the standard pins on ESP8266
@@ -94,6 +102,9 @@ VL6180X sensor;
 #define ALERTCOLOR TFT_RED
 #define TEXTCOLOR TFT_WHITE
 
+//Specify GPIO of pin that the positive lead of piezo buzzer is attached.
+int piezoPin = 15;
+
 // Bar gragh size and position
 int barWidth = 20;
 float barHeight = 144.0;
@@ -113,6 +124,8 @@ int grainsAdded = 50; // For measuring grains per mm
 int grainsAddedStart = 0;
 int grainsAddedFinish = 0;
 int alertPercentGrains = 0;
+
+// 
 
 // For saving some variables to EEPROM, only need minDist, maDist, alertPercent, and grainsPerMM
 // TODO form into struct: https://github.com/esp8266/Arduino/issues/1053
@@ -501,6 +514,7 @@ void doDrawOverlayField(int min, int max)
     delay(1000);                      // Pause for a second to not be pressing the button back in the menu
     subMenuAlertPercent.dirty = true; // Tell the submenu to redraw itself
     subMenuSetGrains.dirty = true;
+      noTone(piezoPin);
     return;
   }
 }
@@ -594,10 +608,12 @@ void drawBar(float nPer)
   if (nPer <= alertPercent)
   {
     GRAPHCOLOR = ALERTCOLOR;
+      tone(piezoPin, 60, 500);
   }
   else
   {
     GRAPHCOLOR = BARCOLOR;
+      noTone(piezoPin);
   }
 
   // Check if above 100% and set the bar to 100% to keep it in the scale


### PR DESCRIPTION
For your consideration:

I added code to set off a piezo alarm if the percentage drops below the defined alarm point.  I'm going to modify the housing so that a piezo can be mounted.  The ones I'm testing with are a little too big to be used on the hopper.

Having this code in place doesn't hurt anything if you aren't using a buzzer.

I'll modify the housing in fusion and send you the design and the stl if you want it.  The one I'm working with is for my dillon, so I'll update it to the correct diameter while I'm at it.  The Dillon hopper body is a little too tight (as some other folks have mentioned as well).